### PR TITLE
Add splay tree

### DIFF
--- a/library/data_structure/splay_tree.hpp
+++ b/library/data_structure/splay_tree.hpp
@@ -1,0 +1,472 @@
+#pragma once
+
+#include <cassert>
+#include <functional>
+
+template <typename K, typename V, typename E, typename F = std::function<V(V, V)>, typename A = std::function<V(V, E)>, typename G = std::function<E(E, E)>>
+class SplayTree {
+   private:
+    struct Node {
+        K key;
+        V value;
+        V acc;
+        E lazy;
+        size_t subtree_size;
+        Node* left_child;
+        Node* right_child;
+        Node* parent;
+
+        Node(const K& key, const V& value) : key(key), value(value), subtree_size(1), left_child(nullptr), right_child(nullptr), parent(nullptr) {}
+    };
+
+    F op;
+    A act;
+    G cp;
+    V e;
+    E id;
+
+    Node* root;
+
+    bool is_left_child(Node* node) {
+        assert(node->parent);
+        assert(node->parent->left_child == node || node->parent->right_child == node);
+        return node == node->parent->left_child;
+    }
+
+    void rotate_left(Node* node) {
+        Node* right = node->right_child;
+        assert(right);
+        node->right_child = right->left_child;
+        if (node->right_child) node->right_child->parent = node;
+        if (node->parent) {
+            (is_left_child(node) ? node->parent->left_child : node->parent->right_child) = right;
+        } else {
+            assert(node == root);
+            root = right;
+        }
+        right->parent = node->parent;
+        right->left_child = node;
+        node->parent = right;
+    }
+
+    void rotate_right(Node* node) {
+        Node* left = node->left_child;
+        assert(left);
+        node->left_child = left->right_child;
+        if (node->left_child) node->left_child->parent = node;
+        if (node->parent) {
+            (is_left_child(node) ? node->parent->left_child : node->parent->right_child) = left;
+        } else {
+            assert(node == root);
+            root = left;
+        }
+        left->parent = node->parent;
+        left->right_child = node;
+        node->parent = left;
+    }
+
+    void splay(Node* node) {
+        while (node && node->parent) {
+            Node* parent = node->parent;
+
+            bool is_left = is_left_child(node);
+
+            if (!parent->parent) {
+                is_left ? rotate_right(parent) : rotate_left(parent);
+                recalc(parent);
+                break;
+            }
+
+            Node* grandparent = parent->parent;
+
+            if (is_left_child(parent) == is_left) {
+                if (is_left) {
+                    rotate_right(grandparent);
+                    rotate_right(parent);
+                } else {
+                    rotate_left(grandparent);
+                    rotate_left(parent);
+                }
+            } else {
+                if (is_left) {
+                    rotate_right(parent);
+                    rotate_left(grandparent);
+                } else {
+                    rotate_left(parent);
+                    rotate_right(grandparent);
+                }
+            }
+
+            recalc(grandparent);
+            recalc(parent);
+            recalc(node);
+        }
+
+        recalc(node);
+    }
+
+    void propagate(Node* node) {
+        if (!node || node->lazy == id) return;
+        node->value = act(node->value, node->lazy);
+        node->acc = act(node->acc, node->lazy);
+        if (node->left_child) {
+            node->left_child->lazy = cp(node->left_child->lazy, node->lazy);
+        }
+        if (node->right_child) {
+            node->right_child->lazy = cp(node->right_child->lazy, node->lazy);
+        }
+        node->lazy = id;
+    }
+
+    void recalc(Node* node) {
+        if (!node) return;
+        node->acc = node->value;
+        node->subtree_size = 1;
+        if (node->left_child) {
+            assert(node->left_child->lazy == id);
+            node->acc = op(node->left_child->acc, node->acc);
+            node->subtree_size += node->left_child->subtree_size;
+        }
+        if (node->right_child) {
+            assert(node->right_child->lazy == id);
+            node->acc = op(node->acc, node->right_child->acc);
+            node->subtree_size += node->right_child->subtree_size;
+        }
+    }
+
+    Node* get_min_key_node(Node* node) {
+        if (!node) return node;
+
+        propagate(node);
+
+        while (node->left_child) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            node = node->left_child;
+        }
+
+        propagate(node->right_child);
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_max_key_node(Node* node) {
+        if (!node) return node;
+
+        propagate(node);
+
+        while (node->right_child) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            node = node->right_child;
+        }
+
+        propagate(node->left_child);
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_kth_node(size_t index) {
+        Node* node = root;
+
+        propagate(node);
+
+        while (true) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (node->left_child) {
+                if (index < node->left_child->subtree_size) {
+                    node = node->left_child;
+                } else if (index == node->left_child->subtree_size) {
+                    break;
+                } else {
+                    index -= node->left_child->subtree_size + 1;
+                    node = node->right_child;
+                }
+            } else {
+                if (index == 0) {
+                    break;
+                } else {
+                    --index;
+                    node = node->right_child;
+                }
+            }
+        }
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* lower_bound(Node* node, const K& key) {
+        Node* ret = nullptr;
+
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (key <= node->key) {
+                ret = node;
+                if (node->left_child)
+                    node = node->left_child;
+                else
+                    break;
+            } else if (node->key < key) {
+                if (node->right_child)
+                    node = node->right_child;
+                else
+                    break;
+            }
+        }
+
+        if (ret) {
+            splay(ret);
+        } else {
+            splay(node);
+        }
+
+        return ret;
+    }
+
+    Node* upper_bound(Node* node, const K& key) {
+        Node* ret = nullptr;
+
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (key < node->key) {
+                ret = node;
+                if (node->left_child)
+                    node = node->left_child;
+                else
+                    break;
+            } else if (node->key <= key) {
+                if (node->right_child)
+                    node = node->right_child;
+                else
+                    break;
+            }
+        }
+
+        if (ret) {
+            splay(ret);
+        } else {
+            splay(node);
+        }
+
+        return ret;
+    }
+
+    Node* split_left(const K& key) {
+        Node* node = lower_bound(root, key);
+
+        Node* left = nullptr;
+
+        if (node) {
+            left = node->left_child;
+            node->left_child = nullptr;
+            if (left) left->parent = nullptr;
+            propagate(node->right_child);
+            recalc(node);
+        } else {
+            left = root;
+            root = nullptr;
+        }
+
+        return left;
+    }
+
+    Node* split_right(const K& key) {
+        Node* right = upper_bound(root, key);
+
+        if (right) {
+            root = right->left_child;
+            right->left_child = nullptr;
+            recalc(right);
+            if (root) {
+                root->parent = nullptr;
+                propagate(root->left_child);
+                recalc(root);
+            }
+        }
+
+        return right;
+    }
+
+    void merge_left(Node* left) {
+        if (root) {
+            root = get_min_key_node(root);
+
+            root->left_child = left;
+            if (root->left_child) {
+                root->left_child->parent = root;
+            }
+
+            propagate(root->left_child);
+            propagate(root->right_child);
+            recalc(root);
+        } else {
+            root = left;
+        }
+    }
+
+    void merge_right(Node* right) {
+        if (root) {
+            root = get_max_key_node(root);
+
+            root->right_child = right;
+            if (root->right_child) {
+                root->right_child->parent = root;
+            }
+
+            propagate(root->left_child);
+            propagate(root->right_child);
+            recalc(root);
+        } else {
+            root = right;
+        }
+    }
+
+   public:
+    SplayTree(const F& op, const A& act, const G& cp, const V& e, const E& id) : op(op), act(act), cp(cp), e(e), id(id), root(nullptr) {}
+
+    bool insert(const K& key, const V& value) {
+        if (contains(key)) return false;
+
+        Node* right = split_right(key);
+        Node* left = root;
+
+        root = new Node(key, value);
+        root->acc = e;
+        root->lazy = id;
+
+        merge_left(left);
+        merge_right(right);
+
+        return true;
+    }
+
+    bool erase(const K& key) {
+        if (!contains(key)) return false;
+
+        Node* left = split_left(key);
+        Node* right = split_right(key);
+
+        delete root;
+        root = nullptr;
+
+        merge_left(left);
+        merge_right(right);
+
+        return true;
+    }
+
+    bool contains(const K& key) {
+        Node* node = lower_bound(root, key);
+        if (node && node->key == key) {
+            assert(node == root);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool update(const K& key, const V& value) {
+        if (!contains(key)) return false;
+
+        assert(root->lazy == id);
+
+        root->value = value;
+        root->acc = value;
+        root->lazy = id;
+
+        propagate(root->left_child);
+        propagate(root->right_child);
+        recalc(root);
+
+        return true;
+    }
+
+    void update(const K& left_key, const K& right_key, const E& g) {
+        Node* left = split_left(left_key);
+        Node* right = split_right(right_key);
+
+        if (root) root->lazy = cp(root->lazy, g);
+
+        merge_left(left);
+        merge_right(right);
+    }
+
+    V fold(const K& left_key, const K& right_key) {
+        Node* left = split_left(left_key);
+        Node* right = split_right(right_key);
+
+        V ret = e;
+        if (root) ret = root->acc;
+
+        merge_left(left);
+        merge_right(right);
+
+        return ret;
+    }
+
+    size_t get_index(const K& key) {
+        assert(contains(key));
+        if (root->left_child)
+            return root->left_child->subtree_size;
+        else
+            return 0;
+    }
+
+    K get_kth_key(size_t index) {
+        assert(index < size());
+        return get_kth_node(index)->key;
+    }
+
+    V fold() const { return root ? root->acc : e; }
+
+    size_t size() const { return root ? root->subtree_size : 0; }
+
+    bool empty() const { return !root; }
+
+    void clear() {
+        Node* node = root;
+
+        while (node) {
+            if (node->left_child) {
+                node = node->left_child;
+            } else if (node->right_child) {
+                node = node->right_child;
+            } else {
+                Node* parent = node->parent;
+                if (parent) {
+                    if (node == parent->left_child) {
+                        delete node;
+                        parent->left_child = nullptr;
+                    } else {
+                        delete node;
+                        parent->right_child = nullptr;
+                    }
+                } else {
+                    delete node;
+                    root = nullptr;
+                }
+                node = parent;
+            }
+        }
+    }
+
+    ~SplayTree() { clear(); }
+};

--- a/test/data_structure/CMakeLists.txt
+++ b/test/data_structure/CMakeLists.txt
@@ -22,6 +22,10 @@ add_executable(SlidingWindowAggregationTest sliding_window_aggregation_test.cpp)
 target_link_libraries(SlidingWindowAggregationTest gtest_main)
 gtest_discover_tests(SlidingWindowAggregationTest)
 
+add_executable(SplayTreeTest splay_tree_test.cpp)
+target_link_libraries(SplayTreeTest gtest_main)
+gtest_discover_tests(SplayTreeTest)
+
 add_executable(UnionFindTest union_find_test.cpp)
 target_link_libraries(UnionFindTest gtest_main)
 gtest_discover_tests(UnionFindTest)

--- a/test/data_structure/splay_tree_test.cpp
+++ b/test/data_structure/splay_tree_test.cpp
@@ -1,0 +1,446 @@
+#include "data_structure/splay_tree.hpp"
+
+#include <gtest/gtest.h>
+
+#include <random>
+#include <set>
+
+#include "data_structure/lazy_segment_tree.hpp"
+
+using namespace std;
+
+TEST(SplayTreeTest, LinearInsert1) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), i);
+        tree.insert(i, 0);
+        ASSERT_FALSE(tree.empty());
+    }
+    ASSERT_EQ(tree.size(), n);
+}
+
+TEST(SplayTreeTest, LinearInsert2) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_EQ(tree.size(), n - i - 1);
+        tree.insert(i, 0);
+        ASSERT_FALSE(tree.empty());
+    }
+    ASSERT_EQ(tree.size(), n);
+}
+
+TEST(SplayTreeTest, LinearErase1) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), n - i);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, LinearErase2) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_EQ(tree.size(), i + 1);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, LinearErase3) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = n - 1; i >= 0; i--) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), n - i);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, LinearErase4) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = n - 1; i >= 0; i--) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_EQ(tree.size(), i + 1);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, InsertAndErase) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    multiset<int> s;
+
+    int n = 3000;
+
+    for (int i = 0; i < n; i++) {
+        int r = i % 3;
+        if (r == 0) {
+            tree.insert(i, 0);
+            s.insert(i);
+        } else if (r == 1) {
+            tree.insert(i + 1, 0);
+            s.insert(i + 1);
+        } else {
+            tree.insert(i - 1, 0);
+            s.insert(i - 1);
+        }
+
+        ASSERT_EQ(tree.size(), s.size());
+
+        if (i % 6 == 5) {
+            tree.erase(i - 3);
+            tree.erase(i - 1);
+
+            s.erase(s.find(i - 3));
+            s.erase(s.find(i - 1));
+        }
+
+        ASSERT_EQ(tree.size(), s.size());
+
+        for (auto e : s) {
+            ASSERT_TRUE(tree.contains(e));
+        }
+    }
+
+    while (!s.empty()) {
+        tree.erase(*s.begin());
+        s.erase(s.begin());
+    }
+
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, GetKthKey) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    multiset<int> s;
+
+    int n = 3000;
+
+    for (int i = 0; i < n; i++) {
+        int r = i % 3;
+        if (r == 0) {
+            tree.insert(i, 0);
+            s.insert(i);
+        } else if (r == 1) {
+            tree.insert(i + 1, 0);
+            s.insert(i + 1);
+        } else {
+            tree.insert(i - 1, 0);
+            s.insert(i - 1);
+        }
+
+        if (i % 6 == 5) {
+            tree.erase(i - 3);
+            tree.erase(i - 1);
+
+            s.erase(s.find(i - 3));
+            s.erase(s.find(i - 1));
+        }
+
+        size_t ord = 0;
+        for (auto e : s) {
+            ASSERT_EQ(tree.get_kth_key(ord++), e);
+        }
+    }
+
+    while (!s.empty()) {
+        tree.erase(*s.begin());
+        s.erase(s.begin());
+
+        size_t ord = 0;
+        for (auto e : s) {
+            ASSERT_EQ(tree.get_index(e), ord++);
+        }
+    }
+}
+
+TEST(SplayTreeTest, Clear) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), i);
+        tree.insert(i, 0);
+    }
+
+    tree.clear();
+
+    ASSERT_TRUE(tree.empty());
+
+    tree.insert(1, 0);
+
+    ASSERT_EQ(tree.size(), 1);
+}
+
+TEST(SplayTreeTest, InsertRangeUpdateRangeMinimumQuery) {
+    int n = 5000;
+    int q = 50000;
+
+    const int MAX = 1e5;
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    uniform_int_distribution<> dist_idx(0, n - 1);
+    uniform_int_distribution<> dist_val(-MAX, MAX);
+
+    const long long INF = 1ll << 60;
+
+    using M = long long;
+    using E = optional<long long>;
+
+    const M e = INF;
+    const E id = nullopt;
+
+    auto op = [](const M& x, const M& y) {
+        return min(x, y);
+    };
+
+    auto cp = [](const E& f, const E& g) {
+        if (g)
+            return g;
+        else
+            return f;
+    };
+
+    auto act = [](const M& x, const E& f) {
+        if (f) return f.value();
+        return x;
+    };
+
+    auto act2 = [](const M& x, const E& f) {
+        if (x == e)
+            return x;
+        else if (f)
+            return f.value();
+        else
+            return x;
+    };
+
+    SplayTree<int, M, E, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, e, id);
+
+    LazySegmentTree<M, E, decltype(op), decltype(act2), decltype(cp)> segtree(n, op, act2, cp, e, id);
+
+    vector<int> contains(n, 0);
+
+    for (int t = 0; t < q; t++) {
+        int i = dist_idx(engine);
+
+        M x = dist_val(engine);
+
+        if (contains[i]) {
+            tree.update(i, x);
+            segtree.update(i, x);
+        } else {
+            tree.insert(i, x);
+            segtree.update(i, x);
+            contains[i] |= 1;
+        }
+
+        int l = dist_idx(engine);
+        int r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        x = dist_val(engine);
+
+        tree.update(l, r - 1, x);
+
+        segtree.update(l, r, x);
+
+        l = dist_idx(engine);
+        r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        ASSERT_EQ(tree.fold(l, r - 1), segtree.fold(l, r));
+        ASSERT_EQ(tree.fold(), segtree.fold());
+    }
+}
+
+TEST(SplayTreeTest, InsertEraseRangeUpdateRangeMinimumQuery) {
+    int n = 5000;
+    int q = 50000;
+
+    const int MAX = 1e5;
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    uniform_int_distribution<> dist_idx(0, n - 1);
+    uniform_int_distribution<> dist_val(-MAX, MAX);
+
+    const long long INF = 1ll << 60;
+
+    using M = long long;
+    using E = optional<long long>;
+
+    const M e = INF;
+    const E id = nullopt;
+
+    auto op = [](const M& x, const M& y) {
+        return min(x, y);
+    };
+
+    auto cp = [](const E& f, const E& g) {
+        if (g)
+            return g;
+        else
+            return f;
+    };
+
+    auto act = [](const M& x, const E& f) {
+        if (f) return f.value();
+        return x;
+    };
+
+    auto act2 = [](const M& x, const E& f) {
+        if (x == e)
+            return x;
+        else if (f)
+            return f.value();
+        else
+            return x;
+    };
+
+    SplayTree<int, M, E, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, e, id);
+
+    LazySegmentTree<M, E, decltype(op), decltype(act2), decltype(cp)> segtree(n, op, act2, cp, e, id);
+
+    vector<int> contains(n, 0);
+
+    for (int t = 0; t < q; t++) {
+        int i = dist_idx(engine);
+
+        M x = dist_val(engine);
+
+        if (contains[i]) {
+            tree.erase(i);
+            segtree.update(i, e);
+            contains[i] ^= 1;
+        } else {
+            tree.insert(i, x);
+            segtree.update(i, x);
+            contains[i] ^= 1;
+        }
+
+        int l = dist_idx(engine);
+        int r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        x = dist_val(engine);
+
+        tree.update(l, r - 1, x);
+
+        segtree.update(l, r, x);
+
+        l = dist_idx(engine);
+        r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        ASSERT_EQ(tree.fold(l, r - 1), segtree.fold(l, r));
+        ASSERT_EQ(tree.fold(), segtree.fold());
+    }
+}


### PR DESCRIPTION
作用素付きモノイドが乗る Splay tree
- 明示的に key をもつ
- reverse なし
- 区間は閉区間 `[left_key, right_key]`

`split_left(KEY)` は `root` の部分木に含まれる `key` $\geq$ `KEY` となるように左側を分離する (`split_right` も同様)

`key` をもたないほうがいいかもしれない