### PR TITLE
Partial retroactive priority queue

### DIFF
--- a/library/data_structure/partial_retroactive_priority_queue.hpp
+++ b/library/data_structure/partial_retroactive_priority_queue.hpp
@@ -1,0 +1,769 @@
+#pragma once
+
+#include <cassert>
+#include <optional>
+
+template <typename T, typename K>
+class PartialRetroactivePriorityQueue {
+   private:
+    struct Node {
+        T time;
+        std::optional<K> key;
+        int label;
+        int prefix_sum_label;
+
+        std::optional<K> max_key_not_contained;
+        std::optional<K> min_key_contained;
+        int min_prefix_sum_label;
+        size_t subtree_size;
+
+        int lazy_prefix_sum_label;
+
+        Node* left_child;
+        Node* right_child;
+        Node* parent;
+
+        Node(const T& time, const std::optional<K>& key, int label)
+            : time(time),
+              key(key),
+              label(label),
+              prefix_sum_label(label),
+              max_key_not_contained(std::nullopt),
+              min_key_contained(key),
+              min_prefix_sum_label(label),
+              lazy_prefix_sum_label(0),
+              subtree_size(1),
+              left_child(nullptr),
+              right_child(nullptr),
+              parent(nullptr) {}
+    };
+
+    Node* root;
+    size_t sz;
+
+    bool is_left_child(Node* node) {
+        assert(node->parent);
+        assert(node->parent->left_child == node || node->parent->right_child == node);
+        return node == node->parent->left_child;
+    }
+
+    void rotate_left(Node* node) {
+        Node* right = node->right_child;
+        assert(right);
+        node->right_child = right->left_child;
+        if (node->right_child) node->right_child->parent = node;
+        if (node->parent) {
+            (is_left_child(node) ? node->parent->left_child : node->parent->right_child) = right;
+        } else {
+            assert(node == root);
+            root = right;
+        }
+        right->parent = node->parent;
+        right->left_child = node;
+        node->parent = right;
+    }
+
+    void rotate_right(Node* node) {
+        Node* left = node->left_child;
+        assert(left);
+        node->left_child = left->right_child;
+        if (node->left_child) node->left_child->parent = node;
+        if (node->parent) {
+            (is_left_child(node) ? node->parent->left_child : node->parent->right_child) = left;
+        } else {
+            assert(node == root);
+            root = left;
+        }
+        left->parent = node->parent;
+        left->right_child = node;
+        node->parent = left;
+    }
+
+    void splay(Node* node) {
+        while (node && node->parent) {
+            Node* parent = node->parent;
+
+            bool is_left = is_left_child(node);
+
+            if (!parent->parent) {
+                is_left ? rotate_right(parent) : rotate_left(parent);
+                recalc(parent);
+                break;
+            }
+
+            Node* grandparent = parent->parent;
+
+            if (is_left_child(parent) == is_left) {
+                if (is_left) {
+                    rotate_right(grandparent);
+                    rotate_right(parent);
+                } else {
+                    rotate_left(grandparent);
+                    rotate_left(parent);
+                }
+            } else {
+                if (is_left) {
+                    rotate_right(parent);
+                    rotate_left(grandparent);
+                } else {
+                    rotate_left(parent);
+                    rotate_right(grandparent);
+                }
+            }
+
+            recalc(grandparent);
+            recalc(parent);
+            recalc(node);
+        }
+
+        recalc(node);
+    }
+
+    bool chmin_key(std::optional<K>& x, const std::optional<K>& y) {
+        if (y) {
+            if (!x || x.value() > y.value()) {
+                x = y;
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    bool chmax_key(std::optional<K>& x, const std::optional<K>& y) {
+        if (y) {
+            if (!x || x.value() < y.value()) {
+                x = y;
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    void propagate(Node* node) {
+        if (!node || node->lazy_prefix_sum_label == 0) return;
+        node->prefix_sum_label += node->lazy_prefix_sum_label;
+        node->min_prefix_sum_label += node->lazy_prefix_sum_label;
+        if (node->left_child) {
+            node->left_child->lazy_prefix_sum_label += node->lazy_prefix_sum_label;
+        }
+        if (node->right_child) {
+            node->right_child->lazy_prefix_sum_label += node->lazy_prefix_sum_label;
+        }
+        node->lazy_prefix_sum_label = 0;
+    }
+
+    void recalc(Node* node) {
+        if (!node) return;
+        node->min_prefix_sum_label = node->prefix_sum_label;
+        node->max_key_not_contained = node->label == 1 ? node->key : std::nullopt;
+        node->min_key_contained = node->label == 0 ? node->key : std::nullopt;
+        node->subtree_size = 1;
+        if (node->left_child) {
+            assert(node->left_child->lazy_prefix_sum_label == 0);
+            node->min_prefix_sum_label = std::min(node->left_child->min_prefix_sum_label, node->min_prefix_sum_label);
+            chmax_key(node->max_key_not_contained, node->left_child->max_key_not_contained);
+            chmin_key(node->min_key_contained, node->left_child->min_key_contained);
+            node->subtree_size += node->left_child->subtree_size;
+        }
+        if (node->right_child) {
+            assert(node->right_child->lazy_prefix_sum_label == 0);
+            node->min_prefix_sum_label = std::min(node->min_prefix_sum_label, node->right_child->min_prefix_sum_label);
+            chmax_key(node->max_key_not_contained, node->right_child->max_key_not_contained);
+            chmin_key(node->min_key_contained, node->right_child->min_key_contained);
+            node->subtree_size += node->right_child->subtree_size;
+        }
+    }
+
+    Node* get_leftmost_node(Node* node) {
+        if (!node) return node;
+
+        propagate(node);
+
+        while (node->left_child) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            node = node->left_child;
+        }
+
+        propagate(node->right_child);
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_rightmost_node(Node* node) {
+        if (!node) return node;
+
+        propagate(node);
+
+        while (node->right_child) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            node = node->right_child;
+        }
+
+        propagate(node->left_child);
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_kth_node(Node* node, size_t index) {
+        propagate(node);
+
+        while (true) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (node->left_child) {
+                if (index < node->left_child->subtree_size) {
+                    node = node->left_child;
+                } else if (index < node->left_child->subtree_size + 1) {
+                    break;
+                } else {
+                    index -= node->left_child->subtree_size + 1;
+                    node = node->right_child;
+                }
+            } else {
+                if (index == 0) {
+                    break;
+                } else {
+                    --index;
+                    node = node->right_child;
+                }
+            }
+        }
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* left_nearest_bridge(const T& time) {
+        Node* right = split_right(time);
+
+        Node* bridge = get_rightmost_node(root);
+
+        assert(bridge);
+
+        propagate(bridge);
+
+        while (bridge) {
+            propagate(bridge->left_child);
+            propagate(bridge->right_child);
+
+            if (bridge->right_child && bridge->right_child->min_prefix_sum_label == 0) {
+                bridge = bridge->right_child;
+            } else if (bridge->prefix_sum_label == 0) {
+                break;
+            } else {
+                bridge = bridge->left_child;
+            }
+        }
+
+        splay(bridge);
+
+        merge_right(right);
+
+        if (bridge) {
+            bridge = upper_bound(root, bridge->time);
+        } else {
+            bridge = get_leftmost_node(root);
+        }
+        assert(bridge);
+
+        splay(bridge);
+
+        return bridge;
+    }
+
+    Node* right_nearest_bridge(const T& time) {
+        Node* right = split_right(time);
+
+        Node* bridge = get_rightmost_node(root);
+
+        merge_right(right);
+
+        assert(bridge);
+        if (bridge->prefix_sum_label > 0) {
+            Node* left = split_left(bridge->time);
+
+            propagate(bridge);
+
+            while (bridge) {
+                propagate(bridge->left_child);
+                propagate(bridge->right_child);
+
+                if (bridge->left_child && bridge->left_child->min_prefix_sum_label == 0) {
+                    bridge = bridge->left_child;
+                } else if (bridge->prefix_sum_label == 0) {
+                    break;
+                } else {
+                    bridge = bridge->right_child;
+                }
+            }
+
+            splay(bridge);
+
+            merge_left(left);
+        }
+
+        return bridge;
+    }
+
+    Node* lower_bound(Node* node, const T& time) {
+        Node* ret = nullptr;
+
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (time <= node->time) {
+                ret = node;
+                if (node->left_child)
+                    node = node->left_child;
+                else
+                    break;
+            } else if (node->time < time) {
+                if (node->right_child)
+                    node = node->right_child;
+                else
+                    break;
+            }
+        }
+
+        if (ret) {
+            splay(ret);
+        } else {
+            splay(node);
+        }
+
+        return ret;
+    }
+
+    Node* upper_bound(Node* node, const T& time) {
+        Node* ret = nullptr;
+
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (time < node->time) {
+                ret = node;
+                if (node->left_child)
+                    node = node->left_child;
+                else
+                    break;
+            } else if (node->time <= time) {
+                if (node->right_child)
+                    node = node->right_child;
+                else
+                    break;
+            }
+        }
+
+        if (ret) {
+            splay(ret);
+        } else {
+            splay(node);
+        }
+
+        return ret;
+    }
+
+    Node* get_rightmost_node_with_max_key_not_contained(Node* node) {
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (node->right_child && node->right_child->max_key_not_contained == node->max_key_not_contained) {
+                node = node->right_child;
+            } else if (node->label == 1 && node->key.value() == node->max_key_not_contained.value()) {
+                break;
+            } else {
+                node = node->left_child;
+            }
+        }
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_leftmost_node_with_min_key_contained(Node* node) {
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (node->left_child && node->left_child->min_key_contained == node->min_key_contained) {
+                node = node->left_child;
+            } else if (node->label == 0 && node->key.value() == node->min_key_contained.value()) {
+                break;
+            } else {
+                node = node->right_child;
+            }
+        }
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* split_left(const T& time) {
+        Node* node = lower_bound(root, time);
+
+        Node* left = nullptr;
+
+        if (node) {
+            left = node->left_child;
+            node->left_child = nullptr;
+            if (left) left->parent = nullptr;
+            propagate(node->right_child);
+            recalc(node);
+        } else {
+            left = root;
+            root = nullptr;
+        }
+
+        return left;
+    }
+
+    Node* split_right(const T& time) {
+        Node* right = upper_bound(root, time);
+
+        if (right) {
+            root = right->left_child;
+            right->left_child = nullptr;
+            recalc(right);
+            if (root) {
+                root->parent = nullptr;
+                propagate(root->left_child);
+                recalc(root);
+            }
+        }
+
+        return right;
+    }
+
+    void merge_left(Node* left) {
+        if (root) {
+            root = get_leftmost_node(root);
+
+            root->left_child = left;
+            if (root->left_child) {
+                root->left_child->parent = root;
+            }
+
+            propagate(root->left_child);
+            propagate(root->right_child);
+            recalc(root);
+        } else {
+            root = left;
+        }
+    }
+
+    void merge_right(Node* right) {
+        if (root) {
+            root = get_rightmost_node(root);
+
+            root->right_child = right;
+            if (root->right_child) {
+                root->right_child->parent = root;
+            }
+
+            propagate(root->left_child);
+            propagate(root->right_child);
+            recalc(root);
+        } else {
+            root = right;
+        }
+    }
+
+   public:
+    PartialRetroactivePriorityQueue() : root(nullptr), sz(0) {}
+
+    bool insert_push(const T& time, const K& key) {
+        if (contains(time)) return false;
+
+        Node* right = split_right(time);
+        Node* left = get_rightmost_node(root);
+
+        root = new Node(time, key, 1);
+        if (left) {
+            propagate(left);
+            root->prefix_sum_label += left->prefix_sum_label;
+        }
+        if (right) ++right->lazy_prefix_sum_label;
+        merge_left(left);
+        merge_right(right);
+
+        Node* bridge = left_nearest_bridge(time);
+
+        left = split_left(bridge->time);
+
+        root = get_rightmost_node_with_max_key_not_contained(root);
+
+        root->label = 0;
+        --(root->prefix_sum_label);
+        right = split_right(root->time);
+        if (right) --right->lazy_prefix_sum_label;
+        merge_left(left);
+        merge_right(right);
+
+        ++sz;
+
+        return true;
+    }
+
+    bool insert_pop(const T& time) {
+        if (contains(time)) return false;
+
+        Node* left = split_left(time);
+        merge_left(left);
+
+        if (!left) {
+            return false;
+        }
+
+        Node* bridge = right_nearest_bridge(time);
+
+        Node* right = split_right(bridge->time);
+
+        if (!root->min_key_contained) {
+            merge_right(right);
+            return false;
+        }
+
+        Node* node = get_leftmost_node_with_min_key_contained(root);
+
+        node->label = 1;
+        ++(node->prefix_sum_label);
+        merge_right(right);
+        right = split_right(node->time);
+        if (right) ++right->lazy_prefix_sum_label;
+        merge_right(right);
+
+        right = split_right(time);
+
+        left = get_rightmost_node(root);
+
+        root = new Node(time, std::nullopt, -1);
+        if (left) {
+            propagate(left);
+            root->prefix_sum_label += left->prefix_sum_label;
+        }
+        if (right) --right->lazy_prefix_sum_label;
+        merge_left(left);
+        merge_right(right);
+
+        --sz;
+
+        return true;
+    }
+
+    T push(const K& key) {
+        Node* node = get_rightmost_node(root);
+        T time = 0;
+        if (node) time = node->time + 1;
+
+        insert_push(time, key);
+
+        return time;
+    }
+
+    T pop() {
+        Node* node = get_rightmost_node(root);
+        T time = node->time + 1;
+
+        insert_pop(time);
+
+        return time;
+    }
+
+    bool erase(const T& time) {
+        if (!contains(time)) return false;
+        
+        if (is_push(time)) {
+            return erase_push(time);
+        } else if (is_pop(time)) {
+            return erase_pop(time);
+        }
+
+        return false;
+    }
+
+    bool erase_pop(const T& time) {
+        if (!is_pop(time)) return false;
+
+        Node* left = split_left(time);
+        Node* right = split_right(time);
+
+        delete root;
+        root = nullptr;
+
+        if (right) ++right->lazy_prefix_sum_label;
+        merge_left(left);
+        merge_right(right);
+
+        Node* bridge = left_nearest_bridge(time);
+
+        left = split_left(bridge->time);
+
+        root = get_rightmost_node_with_max_key_not_contained(root);
+
+        root->label = 0;
+        --(root->prefix_sum_label);
+        right = split_right(root->time);
+        if (right) --right->lazy_prefix_sum_label;
+        merge_left(left);
+        merge_right(right);
+
+        ++sz;
+
+        return true;
+    }
+
+    bool erase_push(const T& time) {
+        if (!is_push(time)) return false;
+
+        if (root->label == 0) {
+            Node* left = split_left(time);
+            Node* right = split_right(time);
+            delete root;
+            root = nullptr;
+            merge_left(left);
+            merge_right(right);
+            --sz;
+            return true;
+        }
+
+        Node* bridge = right_nearest_bridge(time);
+
+        Node* right = split_right(bridge->time);
+
+        if (!root->min_key_contained) {
+            merge_right(right);
+            return false;
+        }
+
+        Node* node = get_leftmost_node_with_min_key_contained(root);
+
+        node->label = 1;
+        ++(node->prefix_sum_label);
+        merge_right(right);
+        right = split_right(node->time);
+        if (right) ++right->lazy_prefix_sum_label;
+        merge_right(right);
+
+        Node* left = split_left(time);
+        right = split_right(time);
+
+        delete root;
+        root = nullptr;
+
+        if (right) --right->lazy_prefix_sum_label;
+        merge_left(left);
+        merge_right(right);
+
+        --sz;
+
+        return true;
+    }
+
+    K top() const {
+        assert(!empty());
+        return root->min_key_contained.value();
+    }
+
+    bool contains(const T& time) {
+        Node* node = lower_bound(root, time);
+        if (node && node->time == time) {
+            assert(node == root);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool is_push(const T& time) {
+        Node* node = lower_bound(root, time);
+        if (node && node->time == time && node->label >= 0) {
+            assert(node == root);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool is_pop(const T& time) {
+        Node* node = lower_bound(root, time);
+        if (node && node->time == time && node->label < 0) {
+            assert(node == root);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    size_t get_index(const T& time) {
+        assert(contains(time));
+        if (root->left_child)
+            return root->left_child->subtree_size;
+        else
+            return 0;
+    }
+
+    K get_kth_time(size_t index) {
+        assert(root && index < root->subtree_size);
+        return get_kth_node(index)->time;
+    }
+
+    size_t operation_sequence_len() const { return root ? root->subtree_size : 0; }
+
+    size_t size() const { return sz; }
+
+    bool empty() const { return sz == 0; }
+
+    void clear() {
+        Node* node = root;
+
+        while (node) {
+            if (node->left_child) {
+                node = node->left_child;
+            } else if (node->right_child) {
+                node = node->right_child;
+            } else {
+                Node* parent = node->parent;
+                if (parent) {
+                    if (node == parent->left_child) {
+                        delete node;
+                        parent->left_child = nullptr;
+                    } else {
+                        delete node;
+                        parent->right_child = nullptr;
+                    }
+                } else {
+                    delete node;
+                    root = nullptr;
+                }
+                node = parent;
+            }
+        }
+    }
+
+    ~PartialRetroactivePriorityQueue() { clear(); }
+};

--- a/library/data_structure/splay_tree.hpp
+++ b/library/data_structure/splay_tree.hpp
@@ -1,0 +1,472 @@
+#pragma once
+
+#include <cassert>
+#include <functional>
+
+template <typename K, typename V, typename E, typename F = std::function<V(V, V)>, typename A = std::function<V(V, E)>, typename G = std::function<E(E, E)>>
+class SplayTree {
+   private:
+    struct Node {
+        K key;
+        V value;
+        V acc;
+        E lazy;
+        size_t subtree_size;
+        Node* left_child;
+        Node* right_child;
+        Node* parent;
+
+        Node(const K& key, const V& value) : key(key), value(value), subtree_size(1), left_child(nullptr), right_child(nullptr), parent(nullptr) {}
+    };
+
+    F op;
+    A act;
+    G cp;
+    V e;
+    E id;
+
+    Node* root;
+
+    bool is_left_child(Node* node) {
+        assert(node->parent);
+        assert(node->parent->left_child == node || node->parent->right_child == node);
+        return node == node->parent->left_child;
+    }
+
+    void rotate_left(Node* node) {
+        Node* right = node->right_child;
+        assert(right);
+        node->right_child = right->left_child;
+        if (node->right_child) node->right_child->parent = node;
+        if (node->parent) {
+            (is_left_child(node) ? node->parent->left_child : node->parent->right_child) = right;
+        } else {
+            assert(node == root);
+            root = right;
+        }
+        right->parent = node->parent;
+        right->left_child = node;
+        node->parent = right;
+    }
+
+    void rotate_right(Node* node) {
+        Node* left = node->left_child;
+        assert(left);
+        node->left_child = left->right_child;
+        if (node->left_child) node->left_child->parent = node;
+        if (node->parent) {
+            (is_left_child(node) ? node->parent->left_child : node->parent->right_child) = left;
+        } else {
+            assert(node == root);
+            root = left;
+        }
+        left->parent = node->parent;
+        left->right_child = node;
+        node->parent = left;
+    }
+
+    void splay(Node* node) {
+        while (node && node->parent) {
+            Node* parent = node->parent;
+
+            bool is_left = is_left_child(node);
+
+            if (!parent->parent) {
+                is_left ? rotate_right(parent) : rotate_left(parent);
+                recalc(parent);
+                break;
+            }
+
+            Node* grandparent = parent->parent;
+
+            if (is_left_child(parent) == is_left) {
+                if (is_left) {
+                    rotate_right(grandparent);
+                    rotate_right(parent);
+                } else {
+                    rotate_left(grandparent);
+                    rotate_left(parent);
+                }
+            } else {
+                if (is_left) {
+                    rotate_right(parent);
+                    rotate_left(grandparent);
+                } else {
+                    rotate_left(parent);
+                    rotate_right(grandparent);
+                }
+            }
+
+            recalc(grandparent);
+            recalc(parent);
+            recalc(node);
+        }
+
+        recalc(node);
+    }
+
+    void propagate(Node* node) {
+        if (!node || node->lazy == id) return;
+        node->value = act(node->value, node->lazy);
+        node->acc = act(node->acc, node->lazy);
+        if (node->left_child) {
+            node->left_child->lazy = cp(node->left_child->lazy, node->lazy);
+        }
+        if (node->right_child) {
+            node->right_child->lazy = cp(node->right_child->lazy, node->lazy);
+        }
+        node->lazy = id;
+    }
+
+    void recalc(Node* node) {
+        if (!node) return;
+        node->acc = node->value;
+        node->subtree_size = 1;
+        if (node->left_child) {
+            assert(node->left_child->lazy == id);
+            node->acc = op(node->left_child->acc, node->acc);
+            node->subtree_size += node->left_child->subtree_size;
+        }
+        if (node->right_child) {
+            assert(node->right_child->lazy == id);
+            node->acc = op(node->acc, node->right_child->acc);
+            node->subtree_size += node->right_child->subtree_size;
+        }
+    }
+
+    Node* get_min_key_node(Node* node) {
+        if (!node) return node;
+
+        propagate(node);
+
+        while (node->left_child) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            node = node->left_child;
+        }
+
+        propagate(node->right_child);
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_max_key_node(Node* node) {
+        if (!node) return node;
+
+        propagate(node);
+
+        while (node->right_child) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            node = node->right_child;
+        }
+
+        propagate(node->left_child);
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* get_kth_node(size_t index) {
+        Node* node = root;
+
+        propagate(node);
+
+        while (true) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (node->left_child) {
+                if (index < node->left_child->subtree_size) {
+                    node = node->left_child;
+                } else if (index == node->left_child->subtree_size) {
+                    break;
+                } else {
+                    index -= node->left_child->subtree_size + 1;
+                    node = node->right_child;
+                }
+            } else {
+                if (index == 0) {
+                    break;
+                } else {
+                    --index;
+                    node = node->right_child;
+                }
+            }
+        }
+
+        splay(node);
+
+        return node;
+    }
+
+    Node* lower_bound(Node* node, const K& key) {
+        Node* ret = nullptr;
+
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (key <= node->key) {
+                ret = node;
+                if (node->left_child)
+                    node = node->left_child;
+                else
+                    break;
+            } else if (node->key < key) {
+                if (node->right_child)
+                    node = node->right_child;
+                else
+                    break;
+            }
+        }
+
+        if (ret) {
+            splay(ret);
+        } else {
+            splay(node);
+        }
+
+        return ret;
+    }
+
+    Node* upper_bound(Node* node, const K& key) {
+        Node* ret = nullptr;
+
+        propagate(node);
+
+        while (node) {
+            propagate(node->left_child);
+            propagate(node->right_child);
+
+            if (key < node->key) {
+                ret = node;
+                if (node->left_child)
+                    node = node->left_child;
+                else
+                    break;
+            } else if (node->key <= key) {
+                if (node->right_child)
+                    node = node->right_child;
+                else
+                    break;
+            }
+        }
+
+        if (ret) {
+            splay(ret);
+        } else {
+            splay(node);
+        }
+
+        return ret;
+    }
+
+    Node* split_left(const K& key) {
+        Node* node = lower_bound(root, key);
+
+        Node* left = nullptr;
+
+        if (node) {
+            left = node->left_child;
+            node->left_child = nullptr;
+            if (left) left->parent = nullptr;
+            propagate(node->right_child);
+            recalc(node);
+        } else {
+            left = root;
+            root = nullptr;
+        }
+
+        return left;
+    }
+
+    Node* split_right(const K& key) {
+        Node* right = upper_bound(root, key);
+
+        if (right) {
+            root = right->left_child;
+            right->left_child = nullptr;
+            recalc(right);
+            if (root) {
+                root->parent = nullptr;
+                propagate(root->left_child);
+                recalc(root);
+            }
+        }
+
+        return right;
+    }
+
+    void merge_left(Node* left) {
+        if (root) {
+            root = get_min_key_node(root);
+
+            root->left_child = left;
+            if (root->left_child) {
+                root->left_child->parent = root;
+            }
+
+            propagate(root->left_child);
+            propagate(root->right_child);
+            recalc(root);
+        } else {
+            root = left;
+        }
+    }
+
+    void merge_right(Node* right) {
+        if (root) {
+            root = get_max_key_node(root);
+
+            root->right_child = right;
+            if (root->right_child) {
+                root->right_child->parent = root;
+            }
+
+            propagate(root->left_child);
+            propagate(root->right_child);
+            recalc(root);
+        } else {
+            root = right;
+        }
+    }
+
+   public:
+    SplayTree(const F& op, const A& act, const G& cp, const V& e, const E& id) : op(op), act(act), cp(cp), e(e), id(id), root(nullptr) {}
+
+    bool insert(const K& key, const V& value) {
+        if (contains(key)) return false;
+
+        Node* right = split_right(key);
+        Node* left = root;
+
+        root = new Node(key, value);
+        root->acc = e;
+        root->lazy = id;
+
+        merge_left(left);
+        merge_right(right);
+
+        return true;
+    }
+
+    bool erase(const K& key) {
+        if (!contains(key)) return false;
+
+        Node* left = split_left(key);
+        Node* right = split_right(key);
+
+        delete root;
+        root = nullptr;
+
+        merge_left(left);
+        merge_right(right);
+
+        return true;
+    }
+
+    bool contains(const K& key) {
+        Node* node = lower_bound(root, key);
+        if (node && node->key == key) {
+            assert(node == root);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool update(const K& key, const V& value) {
+        if (!contains(key)) return false;
+
+        assert(root->lazy == id);
+
+        root->value = value;
+        root->acc = value;
+        root->lazy = id;
+
+        propagate(root->left_child);
+        propagate(root->right_child);
+        recalc(root);
+
+        return true;
+    }
+
+    void update(const K& left_key, const K& right_key, const E& g) {
+        Node* left = split_left(left_key);
+        Node* right = split_right(right_key);
+
+        if (root) root->lazy = cp(root->lazy, g);
+
+        merge_left(left);
+        merge_right(right);
+    }
+
+    V fold(const K& left_key, const K& right_key) {
+        Node* left = split_left(left_key);
+        Node* right = split_right(right_key);
+
+        V ret = e;
+        if (root) ret = root->acc;
+
+        merge_left(left);
+        merge_right(right);
+
+        return ret;
+    }
+
+    size_t get_index(const K& key) {
+        assert(contains(key));
+        if (root->left_child)
+            return root->left_child->subtree_size;
+        else
+            return 0;
+    }
+
+    K get_kth_key(size_t index) {
+        assert(index < size());
+        return get_kth_node(index)->key;
+    }
+
+    V fold() const { return root ? root->acc : e; }
+
+    size_t size() const { return root ? root->subtree_size : 0; }
+
+    bool empty() const { return !root; }
+
+    void clear() {
+        Node* node = root;
+
+        while (node) {
+            if (node->left_child) {
+                node = node->left_child;
+            } else if (node->right_child) {
+                node = node->right_child;
+            } else {
+                Node* parent = node->parent;
+                if (parent) {
+                    if (node == parent->left_child) {
+                        delete node;
+                        parent->left_child = nullptr;
+                    } else {
+                        delete node;
+                        parent->right_child = nullptr;
+                    }
+                } else {
+                    delete node;
+                    root = nullptr;
+                }
+                node = parent;
+            }
+        }
+    }
+
+    ~SplayTree() { clear(); }
+};

--- a/test/data_structure/CMakeLists.txt
+++ b/test/data_structure/CMakeLists.txt
@@ -14,6 +14,10 @@ add_executable(LazySegmentTreeTest lazy_segment_tree_test.cpp)
 target_link_libraries(LazySegmentTreeTest gtest_main)
 gtest_discover_tests(LazySegmentTreeTest)
 
+add_executable(PartialRetroactivePriorityQueueTest partial_retroactive_priority_queue_test.cpp)
+target_link_libraries(PartialRetroactivePriorityQueueTest gtest_main)
+gtest_discover_tests(PartialRetroactivePriorityQueueTest)
+
 add_executable(SegmentTreeTest segment_tree_test.cpp)
 target_link_libraries(SegmentTreeTest gtest_main)
 gtest_discover_tests(SegmentTreeTest)

--- a/test/data_structure/CMakeLists.txt
+++ b/test/data_structure/CMakeLists.txt
@@ -22,6 +22,10 @@ add_executable(SlidingWindowAggregationTest sliding_window_aggregation_test.cpp)
 target_link_libraries(SlidingWindowAggregationTest gtest_main)
 gtest_discover_tests(SlidingWindowAggregationTest)
 
+add_executable(SplayTreeTest splay_tree_test.cpp)
+target_link_libraries(SplayTreeTest gtest_main)
+gtest_discover_tests(SplayTreeTest)
+
 add_executable(UnionFindTest union_find_test.cpp)
 target_link_libraries(UnionFindTest gtest_main)
 gtest_discover_tests(UnionFindTest)

--- a/test/data_structure/partial_retroactive_priority_queue_test.cpp
+++ b/test/data_structure/partial_retroactive_priority_queue_test.cpp
@@ -1,0 +1,327 @@
+#include "data_structure/partial_retroactive_priority_queue.hpp"
+
+#include <gtest/gtest.h>
+
+#include <queue>
+#include <random>
+#include <vector>
+
+using namespace std;
+
+TEST(PartialRetroactivePriorityQueueTest, PushLarge) {
+    PartialRetroactivePriorityQueue<double, int> prpq;
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    for (int i = 0; i < 300000; i++) {
+        if (i % 1000 != 1) {
+            prpq.push(i * (i % 2 ? 1 : -1));
+            pq.push(i * (i % 2 ? 1 : -1));
+
+            ASSERT_EQ(prpq.top(), pq.top());
+            ASSERT_EQ(prpq.size(), pq.size());
+        }
+    }
+}
+
+TEST(PartialRetroactivePriorityQueueTest, PopLarge) {
+    PartialRetroactivePriorityQueue<double, int> prpq;
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    for (int i = 0; i < 300000; i++) {
+        if (i % 1000 != 1) {
+            prpq.push(i * (i % 2 ? 1 : -1));
+            pq.push(i * (i % 2 ? 1 : -1));
+        }
+    }
+
+    while (!pq.empty()) {
+        prpq.pop();
+        pq.pop();
+
+        if (!pq.empty()) {
+            ASSERT_EQ(prpq.top(), pq.top());
+            ASSERT_EQ(prpq.size(), pq.size());
+        }
+    }
+
+    ASSERT_TRUE(prpq.empty());
+}
+
+TEST(PartialRetroactivePriorityQueueTest, PushPopLarge) {
+    PartialRetroactivePriorityQueue<double, int> prpq;
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    for (int i = 0; i < 300000; i++) {
+        if (i % 1000 != 1) {
+            prpq.push(i * (i % 2 ? 1 : -1));
+            pq.push(i * (i % 2 ? 1 : -1));
+        } else {
+            prpq.pop();
+            pq.pop();
+        }
+
+        if (!pq.empty()) {
+            ASSERT_EQ(prpq.top(), pq.top());
+            ASSERT_EQ(prpq.size(), pq.size());
+        }
+    }
+}
+
+TEST(PartialRetroactivePriorityQueueTest, RandomPushPop) {
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    const long long MAX = 1ll << 60;
+
+    uniform_int_distribution<> dist_type(0, 3);
+    uniform_int_distribution<long long> dist_key(-MAX, MAX);
+
+    PartialRetroactivePriorityQueue<int, long long> prpq;
+    priority_queue<long long, vector<long long>, greater<long long>> pq;
+
+    int q = 300000;
+
+    for (int t = 0; t < q; t++) {
+        int p = dist_type(engine);
+        if (p == 0 && !prpq.empty()) {
+            prpq.pop();
+            pq.pop();
+        } else {
+            long long key = dist_key(engine);
+            prpq.push(key);
+            pq.push(key);
+        }
+
+        if (!prpq.empty()) {
+            ASSERT_EQ(prpq.top(), pq.top());
+        }
+    }
+}
+
+TEST(PartialRetroactivePriorityQueueTest, RandomInsertPush) {
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    const int MAX = 100000;
+
+    const int FIRST = -100;
+    const int LAST = 1000;
+
+    uniform_int_distribution<> dist_time(FIRST, LAST);
+    uniform_int_distribution<> dist_key(-MAX, MAX);
+
+    PartialRetroactivePriorityQueue<int, int> prpq;
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    int q = 300000;
+
+    for (int t = 0; t < q; t++) {
+        int time = dist_time(engine);
+        int key = dist_key(engine);
+
+        if (prpq.insert_push(time, key)) {
+            pq.push(key);
+        }
+
+        if (!prpq.empty()) {
+            ASSERT_EQ(prpq.top(), pq.top());
+        }
+
+        ASSERT_EQ(prpq.size(), pq.size());
+    }
+}
+
+TEST(PartialRetroactivePriorityQueueTest, RandomInsertPushInsertPop) {
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    const int MAX_TIME = 1000;
+    const int MAX_KEY = 10000;
+
+    const int POP = MAX_KEY + 100;
+    const int EMPTY = -MAX_KEY - 100;
+
+    uniform_int_distribution<> dist_type(0, 3);
+    uniform_int_distribution<> dist_time(0, MAX_TIME);
+    uniform_int_distribution<> dist_key(-MAX_KEY, MAX_KEY);
+
+    PartialRetroactivePriorityQueue<int, int> prpq;
+    vector<int> operation_sequence(MAX_TIME + 1, EMPTY);
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    int q = 3000;
+
+    for (int t = 0; t < q; t++) {
+        int tp = dist_type(engine);
+        int time = dist_time(engine);
+
+        if (operation_sequence[time] == EMPTY) {
+            if (tp > 0) {
+                int key = dist_key(engine);
+
+                ASSERT_TRUE(prpq.insert_push(time, key));
+
+                operation_sequence[time] = key;
+            } else {
+                int sz = 0;
+                int min_sz = 0;
+                for (int j = 0; j < time; j++) {
+                    if (operation_sequence[j] == POP) {
+                        --sz;
+                    } else if (operation_sequence[j] != EMPTY) {
+                        ++sz;
+                    }
+                }
+
+                --sz;
+                min_sz = min(sz, min_sz);
+
+                for (int j = time + 1; j <= MAX_TIME; j++) {
+                    if (operation_sequence[j] == POP) {
+                        --sz;
+                        min_sz = min(sz, min_sz);
+                    } else if (operation_sequence[j] != EMPTY) {
+                        ++sz;
+                    }
+                }
+
+                if (min_sz < 0) {
+                    ASSERT_FALSE(prpq.insert_pop(time));
+                } else {
+                    ASSERT_TRUE(prpq.insert_pop(time));
+                    operation_sequence[time] = POP;
+                }
+            }
+        }
+
+        for (int j = 0; j <= MAX_TIME; j++) {
+            if (operation_sequence[j] == POP)
+                pq.pop();
+            else if (operation_sequence[j] != EMPTY)
+                pq.push(operation_sequence[j]);
+        }
+
+        if (!prpq.empty()) {
+            ASSERT_EQ(prpq.top(), pq.top());
+        } else {
+            ASSERT_TRUE(pq.empty());
+        }
+
+        ASSERT_EQ(prpq.size(), pq.size());
+
+        while (!pq.empty()) pq.pop();
+    }
+}
+
+TEST(PartialRetroactivePriorityQueueTest, RandomInsertPushInsertPopErase) {
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    const int MAX_TIME = 1000;
+    const int MAX_KEY = 10000;
+
+    const int POP = MAX_KEY + 100;
+    const int EMPTY = -MAX_KEY - 100;
+
+    uniform_int_distribution<> dist_type(0, 3);
+    uniform_int_distribution<> dist_time(0, MAX_TIME);
+    uniform_int_distribution<> dist_key(-MAX_KEY, MAX_KEY);
+
+    PartialRetroactivePriorityQueue<int, int> prpq;
+    vector<int> operation_sequence(MAX_TIME + 1, EMPTY);
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    int q = 3000;
+
+    for (int t = 0; t < q; t++) {
+        int time = dist_time(engine);
+
+        if (operation_sequence[time] == EMPTY) {
+            int tp = dist_type(engine);
+            if (tp > 1) {
+                int key = dist_key(engine);
+
+                ASSERT_TRUE(prpq.insert_push(time, key));
+
+                operation_sequence[time] = key;
+            } else {
+                int sz = 0;
+                int min_sz = 0;
+                for (int j = 0; j < time; j++) {
+                    if (operation_sequence[j] == POP) {
+                        --sz;
+                    } else if (operation_sequence[j] != EMPTY) {
+                        ++sz;
+                    }
+                }
+
+                --sz;
+                min_sz = min(sz, min_sz);
+
+                for (int j = time + 1; j <= MAX_TIME; j++) {
+                    if (operation_sequence[j] == POP) {
+                        --sz;
+                        min_sz = min(sz, min_sz);
+                    } else if (operation_sequence[j] != EMPTY) {
+                        ++sz;
+                    }
+                }
+
+                if (min_sz < 0) {
+                    ASSERT_FALSE(prpq.insert_pop(time));
+                } else {
+                    ASSERT_TRUE(prpq.insert_pop(time));
+                    operation_sequence[time] = POP;
+                }
+            }
+        } else {
+            if (operation_sequence[time] == POP) {
+                ASSERT_TRUE(prpq.erase(time));
+                operation_sequence[time] = EMPTY;
+            } else {
+                int sz = 0;
+                int min_sz = 0;
+                for (int j = 0; j < time; j++) {
+                    if (operation_sequence[j] == POP) {
+                        --sz;
+                    } else if (operation_sequence[j] != EMPTY) {
+                        ++sz;
+                    }
+                }
+
+                for (int j = time + 1; j <= MAX_TIME; j++) {
+                    if (operation_sequence[j] == POP) {
+                        --sz;
+                        min_sz = min(sz, min_sz);
+                    } else if (operation_sequence[j] != EMPTY) {
+                        ++sz;
+                    }
+                }
+
+                if (min_sz < 0) {
+                    ASSERT_FALSE(prpq.erase(time));
+                } else {
+                    ASSERT_TRUE(prpq.erase(time));
+                    operation_sequence[time] = EMPTY;
+                }
+            }
+        }
+
+        for (int j = 0; j <= MAX_TIME; j++) {
+            if (operation_sequence[j] == POP)
+                pq.pop();
+            else if (operation_sequence[j] != EMPTY)
+                pq.push(operation_sequence[j]);
+        }
+
+        if (!prpq.empty()) {
+            ASSERT_EQ(prpq.top(), pq.top());
+        } else {
+            ASSERT_TRUE(pq.empty());
+        }
+
+        ASSERT_EQ(prpq.size(), pq.size());
+
+        while (!pq.empty()) pq.pop();
+    }
+}

--- a/test/data_structure/splay_tree_test.cpp
+++ b/test/data_structure/splay_tree_test.cpp
@@ -1,0 +1,446 @@
+#include "data_structure/splay_tree.hpp"
+
+#include <gtest/gtest.h>
+
+#include <random>
+#include <set>
+
+#include "data_structure/lazy_segment_tree.hpp"
+
+using namespace std;
+
+TEST(SplayTreeTest, LinearInsert1) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), i);
+        tree.insert(i, 0);
+        ASSERT_FALSE(tree.empty());
+    }
+    ASSERT_EQ(tree.size(), n);
+}
+
+TEST(SplayTreeTest, LinearInsert2) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_EQ(tree.size(), n - i - 1);
+        tree.insert(i, 0);
+        ASSERT_FALSE(tree.empty());
+    }
+    ASSERT_EQ(tree.size(), n);
+}
+
+TEST(SplayTreeTest, LinearErase1) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), n - i);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, LinearErase2) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_EQ(tree.size(), i + 1);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, LinearErase3) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = n - 1; i >= 0; i--) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), n - i);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, LinearErase4) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = n - 1; i >= 0; i--) {
+        tree.insert(i, 0);
+    }
+
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_EQ(tree.size(), i + 1);
+        ASSERT_FALSE(tree.empty());
+        tree.erase(i);
+    }
+    ASSERT_EQ(tree.size(), 0);
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, InsertAndErase) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    multiset<int> s;
+
+    int n = 3000;
+
+    for (int i = 0; i < n; i++) {
+        int r = i % 3;
+        if (r == 0) {
+            tree.insert(i, 0);
+            s.insert(i);
+        } else if (r == 1) {
+            tree.insert(i + 1, 0);
+            s.insert(i + 1);
+        } else {
+            tree.insert(i - 1, 0);
+            s.insert(i - 1);
+        }
+
+        ASSERT_EQ(tree.size(), s.size());
+
+        if (i % 6 == 5) {
+            tree.erase(i - 3);
+            tree.erase(i - 1);
+
+            s.erase(s.find(i - 3));
+            s.erase(s.find(i - 1));
+        }
+
+        ASSERT_EQ(tree.size(), s.size());
+
+        for (auto e : s) {
+            ASSERT_TRUE(tree.contains(e));
+        }
+    }
+
+    while (!s.empty()) {
+        tree.erase(*s.begin());
+        s.erase(s.begin());
+    }
+
+    ASSERT_TRUE(tree.empty());
+}
+
+TEST(SplayTreeTest, GetKthKey) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    multiset<int> s;
+
+    int n = 3000;
+
+    for (int i = 0; i < n; i++) {
+        int r = i % 3;
+        if (r == 0) {
+            tree.insert(i, 0);
+            s.insert(i);
+        } else if (r == 1) {
+            tree.insert(i + 1, 0);
+            s.insert(i + 1);
+        } else {
+            tree.insert(i - 1, 0);
+            s.insert(i - 1);
+        }
+
+        if (i % 6 == 5) {
+            tree.erase(i - 3);
+            tree.erase(i - 1);
+
+            s.erase(s.find(i - 3));
+            s.erase(s.find(i - 1));
+        }
+
+        size_t ord = 0;
+        for (auto e : s) {
+            ASSERT_EQ(tree.get_kth_key(ord++), e);
+        }
+    }
+
+    while (!s.empty()) {
+        tree.erase(*s.begin());
+        s.erase(s.begin());
+
+        size_t ord = 0;
+        for (auto e : s) {
+            ASSERT_EQ(tree.get_index(e), ord++);
+        }
+    }
+}
+
+TEST(SplayTreeTest, Clear) {
+    auto op = [](int x, int y) { return 0; };
+
+    auto act = [](int x, int f) { return 0; };
+
+    auto cp = [](int f, int g) { return 0; };
+
+    SplayTree<int, int, int, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, 0, 0);
+
+    int n = 300000;
+
+    for (int i = 0; i < n; i++) {
+        ASSERT_EQ(tree.size(), i);
+        tree.insert(i, 0);
+    }
+
+    tree.clear();
+
+    ASSERT_TRUE(tree.empty());
+
+    tree.insert(1, 0);
+
+    ASSERT_EQ(tree.size(), 1);
+}
+
+TEST(SplayTreeTest, InsertRangeUpdateRangeMinimumQuery) {
+    int n = 5000;
+    int q = 50000;
+
+    const int MAX = 1e5;
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    uniform_int_distribution<> dist_idx(0, n - 1);
+    uniform_int_distribution<> dist_val(-MAX, MAX);
+
+    const long long INF = 1ll << 60;
+
+    using M = long long;
+    using E = optional<long long>;
+
+    const M e = INF;
+    const E id = nullopt;
+
+    auto op = [](const M& x, const M& y) {
+        return min(x, y);
+    };
+
+    auto cp = [](const E& f, const E& g) {
+        if (g)
+            return g;
+        else
+            return f;
+    };
+
+    auto act = [](const M& x, const E& f) {
+        if (f) return f.value();
+        return x;
+    };
+
+    auto act2 = [](const M& x, const E& f) {
+        if (x == e)
+            return x;
+        else if (f)
+            return f.value();
+        else
+            return x;
+    };
+
+    SplayTree<int, M, E, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, e, id);
+
+    LazySegmentTree<M, E, decltype(op), decltype(act2), decltype(cp)> segtree(n, op, act2, cp, e, id);
+
+    vector<int> contains(n, 0);
+
+    for (int t = 0; t < q; t++) {
+        int i = dist_idx(engine);
+
+        M x = dist_val(engine);
+
+        if (contains[i]) {
+            tree.update(i, x);
+            segtree.update(i, x);
+        } else {
+            tree.insert(i, x);
+            segtree.update(i, x);
+            contains[i] |= 1;
+        }
+
+        int l = dist_idx(engine);
+        int r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        x = dist_val(engine);
+
+        tree.update(l, r - 1, x);
+
+        segtree.update(l, r, x);
+
+        l = dist_idx(engine);
+        r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        ASSERT_EQ(tree.fold(l, r - 1), segtree.fold(l, r));
+        ASSERT_EQ(tree.fold(), segtree.fold());
+    }
+}
+
+TEST(SplayTreeTest, InsertEraseRangeUpdateRangeMinimumQuery) {
+    int n = 5000;
+    int q = 50000;
+
+    const int MAX = 1e5;
+    random_device seed_gen;
+    mt19937 engine(seed_gen());
+
+    uniform_int_distribution<> dist_idx(0, n - 1);
+    uniform_int_distribution<> dist_val(-MAX, MAX);
+
+    const long long INF = 1ll << 60;
+
+    using M = long long;
+    using E = optional<long long>;
+
+    const M e = INF;
+    const E id = nullopt;
+
+    auto op = [](const M& x, const M& y) {
+        return min(x, y);
+    };
+
+    auto cp = [](const E& f, const E& g) {
+        if (g)
+            return g;
+        else
+            return f;
+    };
+
+    auto act = [](const M& x, const E& f) {
+        if (f) return f.value();
+        return x;
+    };
+
+    auto act2 = [](const M& x, const E& f) {
+        if (x == e)
+            return x;
+        else if (f)
+            return f.value();
+        else
+            return x;
+    };
+
+    SplayTree<int, M, E, decltype(op), decltype(act), decltype(cp)> tree(op, act, cp, e, id);
+
+    LazySegmentTree<M, E, decltype(op), decltype(act2), decltype(cp)> segtree(n, op, act2, cp, e, id);
+
+    vector<int> contains(n, 0);
+
+    for (int t = 0; t < q; t++) {
+        int i = dist_idx(engine);
+
+        M x = dist_val(engine);
+
+        if (contains[i]) {
+            tree.erase(i);
+            segtree.update(i, e);
+            contains[i] ^= 1;
+        } else {
+            tree.insert(i, x);
+            segtree.update(i, x);
+            contains[i] ^= 1;
+        }
+
+        int l = dist_idx(engine);
+        int r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        x = dist_val(engine);
+
+        tree.update(l, r - 1, x);
+
+        segtree.update(l, r, x);
+
+        l = dist_idx(engine);
+        r = dist_idx(engine);
+
+        if (l > r) swap(l, r);
+        ++r;
+
+        ASSERT_EQ(tree.fold(l, r - 1), segtree.fold(l, r));
+        ASSERT_EQ(tree.fold(), segtree.fold());
+    }
+}


### PR DESCRIPTION
# Partial retroactive priority queue

平衡二分探索木として splay tree を使用

## 操作列
`push(key)` と `pop` からなる操作列を扱う
- `insert_push(time, key)`   
   時刻 `time` に操作 `push(key)` を追加 (時刻 `time` にすでに操作があればなにもしない)
- `insert_pop(time)`  
   時刻 `time` に操作 `pop` を追加 (時刻 `time` にすでに操作があったり `pop` の追加によってキューが壊れたりする場合はなにもしない)
- `erase_push(time)`  
   時刻 `time` の操作 `push` を削除 (時刻 `time` に操作 `push` がなかったり `push` の削除によってキューが壊れたりする場合は何もしない)
- `erase_pop(time)`  
   時刻 `time` の操作 `pop` を削除 (時刻 `time` に操作 `pop` がなければなにもしない)

普通の優先度付きキューとしても使用できる
その場合は自動的に付与された時刻 `time` が返ってくる

添え字と `time` の変換ができる
`time` の型 `T` を `double` にすると操作列の間に追加しやすい

## ブリッジ
`node->prefix_sum_label` $=$ `0` であるような頂点 `node` はその操作の直後がブリッジであることを示す

関数 `left_nearest_bridge(time)` は 1 つ左の頂点 `node` が (存在すれば) `node->prefix_sum_label` $=$ `0` となるような頂点 `bridge` を返す
`node->time` $\leq$ `time` を満たす (`bridge->time` $\leq$ `time` を満たすとは限らない)
この関数が呼ばれる場所では必ずこのような頂点 `bridge` が存在する

関数 `right_nearest_bridge(time)` は `time` $\leq$ `bridge->time` かつ `bridge->prefix_sum_label` $=$ `0` となるような頂点 `bridge` を返す
この関数が呼ばれる場所では必ずこのような頂点 `bridge` が存在する